### PR TITLE
Use `tt` tag for `code` wiki tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosemirror-wikitext",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ProseMirror Wikitext integration",
   "main": "src/index.js",
   "license": "MIT",

--- a/src/schema/schema-standard.js
+++ b/src/schema/schema-standard.js
@@ -91,8 +91,8 @@ const marks = {
   },
 
   code: {
-    parseDOM: [{tag: "code"}],
-    toDOM() { return ["code"] }
+    parseDOM: [{tag: "tt"}],
+    toDOM() { return ["tt"] }
   },
 
   strikethrough: {


### PR DESCRIPTION
This matches what the wiki renderer uses (see the [XHTML renderer](https://github.com/iFixit/ifixit/blob/master/Objects/Text/Wiki/Render/Xhtml/Ifixit/Teletype.php) and the [JSON renderer](https://github.com/iFixit/ifixit/blob/master/Objects/Text/Wiki/Render/Json/Ifixit/Teletype.php)).