### PR TITLE
Serializer: Support inline marks within blockquote attribution

### DIFF
--- a/src/to_wiki.js
+++ b/src/to_wiki.js
@@ -11,16 +11,19 @@ class WikiTextSerializer {
    }
 
    serialize(content) {
-      let state = new WikiTextSerializerState(this.nodes, this.marks)
+      const schema = content.type.schema
+      const state = new WikiTextSerializerState(this.nodes, this.marks, schema)
+
       state.renderDoc(content)
       return state.out.trim()
    }
 }
 
 class WikiTextSerializerState {
-   constructor(nodes, marks) {
+   constructor(nodes, marks, schema) {
       this.nodes = nodes
       this.marks = marks
+      this.schema = schema
       this.prefix = ""
       this.out = ""
    }
@@ -172,8 +175,14 @@ const serializer = new WikiTextSerializer({
 
       state.out += "[quote"
 
+      // A blockquote attribute can be rich text, so we store it in a node
+      // attribute and then built it into an actual node using
+      // schema.nodeFromJSON.
       if (attribute && attribute !== attrSpec.attribute.default) {
-         state.out += "|" + attribute
+         state.out += "|"
+
+         attribute = state.schema.nodeFromJSON(attribute)
+         state.inline(attribute)
       }
 
       if (format && format !== attrSpec.format.default) {

--- a/tests/standard.js
+++ b/tests/standard.js
@@ -50,8 +50,13 @@ const tests = [
    },
    {
       'name': 'blockquote_with_attribution',
-      'input': {"type":"doc","content":[{"type":"blockquote","attrs":{"format":"long","attribute":"Abraham Lincoln"}, "content":[{"type":"paragraph","content":[{"type":"text","text":"This is a quote."}]}]}]},
+      'input': {"type":"doc","content":[{"type":"blockquote","attrs":{"format":"long","attribute": {"type": "paragraph", "content": [{"type": "text", "text": "Abraham Lincoln"}]}}, "content":[{"type":"paragraph","content":[{"type":"text","text":"This is a quote."}]}]}]},
       'expected': "[quote|Abraham Lincoln]\nThis is a quote.\n\n[/quote]"
+   },
+   {
+      'name': 'blockquote_with_bold_attribution',
+      'input': {"type":"doc","content":[{"type":"blockquote","attrs":{"format":"long","attribute": {"type": "paragraph", "content": [{"type": "text", "marks": [{"type": "strong"}], "type": "text", "text": "Abraham"}, {"type": "text", "text": " Lincoln"}]}}, "content":[{"type":"paragraph","content":[{"type":"text","text":"This is a quote."}]}]}]},
+      'expected': "[quote|'''Abraham''' Lincoln]\nThis is a quote.\n\n[/quote]"
    },
    {
       'name': 'blockquote_with_format',


### PR DESCRIPTION
The iFixit wiki syntax supports using inline marks within the
attribution field, so in order to not break compatability the serializer
needs to be able to round trip existing blockquotes with inline marks in
their attribution fields.

qa_req 0 since comes with test coverage.